### PR TITLE
feature/filters_multiple_categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `ProductFilter`
 - `year_collection` field to `TotalProductsSerializer`
 - `DEBUG_TOOLBAR_ENABLE` settings variable 
+- `ProductFilter` added property for filter by coma-separated list and range for values
 
 ### Moved
 - **Filters** - `product/filters.py`
@@ -19,6 +20,8 @@
 ### Changed
 - Removed duplicate `category` field from `Product` model
 - Dynamic calculation of `CLOUDINARY_FIXED_PREFIX_PATH_ACCOUNT` in `settings.py`
+- Django Admin `ProductAdmin`: added formfield_for_foreignkey() and `_sort_related_fields_byid` for sorf by `pk` {"category", "subcategory", "collection"}
+- At `Category`, `Subcategory`, `Collection` models changed string representation with pk index in text
 
 ---
 ## 2025-09-04 — pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `year_collection` field to `TotalProductsSerializer`
 - `DEBUG_TOOLBAR_ENABLE` settings variable 
 - `ProductFilter` added property for filter by coma-separated list and range for values
+- `CommaSeparatedIntegerListFilter` custom solution coma-separated list of integer values
 
 ### Moved
 - **Filters** - `product/filters.py`

--- a/project_1444/addons/filters.py
+++ b/project_1444/addons/filters.py
@@ -1,0 +1,25 @@
+import django_filters
+from rest_framework.exceptions import ValidationError
+
+
+class CommaSeparatedIntegerListFilter(
+    django_filters.BaseInFilter, django_filters.CharFilter
+):
+    lookup_expr = "in"
+
+    def filter(self, qs, value):
+        if not value:
+            return qs
+
+        try:
+            cleaned = [int(v) for v in value]
+        except ValueError:
+            raise ValidationError(
+                {
+                    self.field_name.split("_")[0]: [
+                        "Expected comma-separated integers in filters"
+                    ]
+                }
+            )
+
+        return super().filter(qs, cleaned)

--- a/project_1444/product/admin.py
+++ b/project_1444/product/admin.py
@@ -551,11 +551,12 @@ class ProductAdmin(TranslatableAdmin):
                 return field
 
             def label_from_instance(obj):
-                return f"{obj.pk:03d}-{obj.safe_translation_getter(
+                field_translated = obj.safe_translation_getter(
                     "name",
                     language_code=lang,
                     any_language=True,
-                )}"
+                )
+                return f"{obj.pk:03d}-{field_translated}"
 
             field.label_from_instance = label_from_instance
 

--- a/project_1444/product/admin.py
+++ b/project_1444/product/admin.py
@@ -1,7 +1,9 @@
+from django.contrib import admin
 from django.utils.html import format_html
-from django.utils.translation import get_language
-from django.shortcuts import get_object_or_404
-from .models import (
+from django.utils.translation import gettext_lazy as _
+from parler.admin import TranslatableAdmin
+
+from product.models import (
     Categories,
     Material,
     Gemstone,
@@ -11,7 +13,6 @@ from .models import (
     Origin,
     ProductImage,
     ProductCertificate,
-    RingSizeConversion,
     Occasion,
     RingSizeConversion,
     Colors,
@@ -28,14 +29,6 @@ from .models import (
     Styles,
     Descriptions,
 )
-from django.contrib import admin
-from parler.admin import TranslatableAdmin, TranslatableTabularInline
-from django.utils.translation import gettext_lazy as _
-from django import forms
-from django.urls import path
-from django.shortcuts import redirect
-from django.utils import translation
-from django.utils.text import slugify
 
 
 @admin.register(Descriptions)
@@ -149,7 +142,7 @@ class RingSizeAdmin(admin.ModelAdmin):
 
 @admin.register(Categories)
 class CategoriesAdmin(TranslatableAdmin):
-    list_display = ("name", "slug")
+    list_display = ("id", "name", "slug")
 
     def get_prepopulated_fields(self, request, obj=None):
         return {"slug": ("name",)}
@@ -214,6 +207,7 @@ class CollectionsAdmin(TranslatableAdmin):
 @admin.register(SubCategories)
 class SubCategoriesAdmin(TranslatableAdmin):
     list_display = (
+        "id",
         "name",
         "slug",
     )

--- a/project_1444/product/admin.py
+++ b/project_1444/product/admin.py
@@ -29,6 +29,7 @@ from product.models import (
     Styles,
     Descriptions,
 )
+from project_1444.settings import LANGUAGE_CODE
 
 
 @admin.register(Descriptions)
@@ -400,6 +401,10 @@ class ProductAdmin(TranslatableAdmin):
         "get_certificates",
     )
     search_fields = ("name", "sku", "ean_13", "category__name", "subcategory__name")
+    list_select_related = (
+        "category",
+        "subcategory",
+    )
     readonly_fields = (
         "sku",
         "article",
@@ -475,6 +480,8 @@ class ProductAdmin(TranslatableAdmin):
         ),
     )
 
+    _sort_related_fields_byid = {"category", "subcategory", "collection"}
+
     def get_images(self, obj):
         """Показує перше зображення товару в списку товарів"""
         first_image = obj.images.first()
@@ -531,6 +538,28 @@ class ProductAdmin(TranslatableAdmin):
 
     def get_prepopulated_fields(self, request, obj=None):
         return {"slug": ("name",)}
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name in self._sort_related_fields_byid:
+            qs = db_field.related_model.objects.all().order_by("pk")
+            kwargs["queryset"] = qs
+        field = super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+        if db_field.name in self._sort_related_fields_byid:
+            lang = request.GET.get("language")
+            if not lang or lang == LANGUAGE_CODE:
+                return field
+
+            def label_from_instance(obj):
+                return f"{obj.pk:03d}-{obj.safe_translation_getter(
+                    "name",
+                    language_code=lang,
+                    any_language=True,
+                )}"
+
+            field.label_from_instance = label_from_instance
+
+        return field
 
 
 # Адмінка для подій (на які випадки можна дарувати товар)

--- a/project_1444/product/filters.py
+++ b/project_1444/product/filters.py
@@ -1,9 +1,14 @@
 import django_filters
 
+from addons.filters import CommaSeparatedIntegerListFilter
 from product.models import Product, Categories
 
 
 class ProductFilter(django_filters.FilterSet):
+    category_list = CommaSeparatedIntegerListFilter(field_name="category_id")
+    subcategory_list = CommaSeparatedIntegerListFilter(field_name="subcategory_id")
+    year_collection_range = django_filters.RangeFilter(field_name="year_collection")
+
     class Meta:
         model = Product
         fields = (

--- a/project_1444/product/models.py
+++ b/project_1444/product/models.py
@@ -36,7 +36,8 @@ class Categories(TranslatableModel):
         verbose_name_plural = _("Категорії виробів")
 
     def __str__(self):
-        return f"{self.pk:03d}-{self.safe_translation_getter("name", default=_("Без назви"))}"
+        field_translated = self.safe_translation_getter("name", default=_("Без назви"))
+        return f"{self.pk:03d}-{field_translated}"
 
 
 class Weaving(TranslatableModel):
@@ -114,7 +115,8 @@ class SubCategories(TranslatableModel):
         verbose_name_plural = _("Підкатегорії виробів")
 
     def __str__(self):
-        return f"{self.pk:03d}-{self.safe_translation_getter("name", default=_("Без назви"))}"
+        field_translated = self.safe_translation_getter("name", default=_("Без назви"))
+        return f"{self.pk:03d}-{field_translated}"
 
 
 class Colors(TranslatableModel):
@@ -150,7 +152,8 @@ class Collections(TranslatableModel):
         verbose_name_plural = _("Колекції")
 
     def __str__(self):
-        return f"{self.pk:03d}-{self.safe_translation_getter("name", default=_("Без назви"))}"
+        field_translated = self.safe_translation_getter("name", default=_("Без назви"))
+        return f"{self.pk:03d}-{field_translated}"
 
 
 class Designs(TranslatableModel):

--- a/project_1444/product/models.py
+++ b/project_1444/product/models.py
@@ -36,9 +36,7 @@ class Categories(TranslatableModel):
         verbose_name_plural = _("Категорії виробів")
 
     def __str__(self):
-        return f"{self.pk:03d}-{self.safe_translation_getter(
-            "name", default=_("Без назви")
-        )}"
+        return f"{self.pk:03d}-{self.safe_translation_getter("name", default=_("Без назви"))}"
 
 
 class Weaving(TranslatableModel):
@@ -116,9 +114,7 @@ class SubCategories(TranslatableModel):
         verbose_name_plural = _("Підкатегорії виробів")
 
     def __str__(self):
-        return f"{self.pk:03d}-{self.safe_translation_getter(
-            "name", default=_("Без назви")
-        )}"
+        return f"{self.pk:03d}-{self.safe_translation_getter("name", default=_("Без назви"))}"
 
 
 class Colors(TranslatableModel):
@@ -154,9 +150,7 @@ class Collections(TranslatableModel):
         verbose_name_plural = _("Колекції")
 
     def __str__(self):
-        return f"{self.pk:03d}-{self.safe_translation_getter(
-            "name", default=_("Без назви")
-        )}"
+        return f"{self.pk:03d}-{self.safe_translation_getter("name", default=_("Без назви"))}"
 
 
 class Designs(TranslatableModel):

--- a/project_1444/product/models.py
+++ b/project_1444/product/models.py
@@ -38,7 +38,7 @@ class Categories(TranslatableModel):
     def __str__(self):
         return f"{self.pk:03d}-{self.safe_translation_getter(
             "name", default=_("Без назви")
-        )}"  # Бере name із перекладу
+        )}"
 
 
 class Weaving(TranslatableModel):
@@ -154,9 +154,9 @@ class Collections(TranslatableModel):
         verbose_name_plural = _("Колекції")
 
     def __str__(self):
-        return self.safe_translation_getter(
+        return f"{self.pk:03d}-{self.safe_translation_getter(
             "name", default=_("Без назви")
-        )  # Бере name із перекладу
+        )}"
 
 
 class Designs(TranslatableModel):

--- a/project_1444/product/models.py
+++ b/project_1444/product/models.py
@@ -36,9 +36,9 @@ class Categories(TranslatableModel):
         verbose_name_plural = _("Категорії виробів")
 
     def __str__(self):
-        return self.safe_translation_getter(
+        return f"{self.pk:03d}-{self.safe_translation_getter(
             "name", default=_("Без назви")
-        )  # Бере name із перекладу
+        )}"  # Бере name із перекладу
 
 
 class Weaving(TranslatableModel):
@@ -116,7 +116,9 @@ class SubCategories(TranslatableModel):
         verbose_name_plural = _("Підкатегорії виробів")
 
     def __str__(self):
-        return self.safe_translation_getter("name", default=_("Без назви"))
+        return f"{self.pk:03d}-{self.safe_translation_getter(
+            "name", default=_("Без назви")
+        )}"
 
 
 class Colors(TranslatableModel):

--- a/project_1444/product/utils.py
+++ b/project_1444/product/utils.py
@@ -36,9 +36,9 @@ def get_discounted_price(user, subproduct):
     - old_price: Оригінальна ціна (Decimal)
     - discount_applied: Застосований відсоток знижки (Decimal)
     """
-    print(
-        f"User: {user}, Subproduct: {subproduct}, Authenticated: {user.is_authenticated if user else False}"
-    )
+    # print(
+    #     f"User: {user}, Subproduct: {subproduct}, Authenticated: {user.is_authenticated if user else False}"
+    # )
     original_price = subproduct.price
     discounts = []
 


### PR DESCRIPTION
- `ProductFilter` added property for filter by coma-separated list and range for values
- `CommaSeparatedIntegerListFilter` custom solution coma-separated list of integer values
- Django Admin `ProductAdmin`: added formfield_for_foreignkey() and `_sort_related_fields_byid` for sorf by `pk` {"category", "subcategory", "collection"}
- At `Category`, `Subcategory`, `Collection` models changed string representation with pk index in text